### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Model Context Protocol server for interacting with the [Iaptic API](https://www.iaptic.com). This server allows Claude or other AIs to interact with your Iaptic data to answer questions about your customers, purchases, transactions, and statistics.
 
+<a href="https://glama.ai/mcp/servers/u2l6kenhz6"><img width="380" height="200" src="https://glama.ai/mcp/servers/u2l6kenhz6/badge" alt="Iaptic Server MCP server" /></a>
+
 ## Installation
 
 ```bash


### PR DESCRIPTION
This PR adds a badge for the [Iaptic MCP Server](https://glama.ai/mcp/servers/u2l6kenhz6) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/u2l6kenhz6"><img width="380" height="200" src="https://glama.ai/mcp/servers/u2l6kenhz6/badge" alt="Iaptic Server MCP server" /></a>

Glama performs regular codebase and documentation scans to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.